### PR TITLE
Add quantization backend abstraction and PseudoQuantBackend with CLI wiring

### DIFF
--- a/evaluation/test_7scenes.py
+++ b/evaluation/test_7scenes.py
@@ -85,6 +85,13 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="If set, include per-pair rotation/translation errors in output JSON.",
     )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="pseudo",
+        choices=["pseudo", "torchao", "bitsandbytes", "trt_int8"],
+        help="Quantization backend to use.",
+    )
     return parser.parse_args()
 
 
@@ -386,8 +393,11 @@ def main() -> None:
     model = load_model(
         args.model_path,
         model_args={"enable_point": False, "enable_depth": False, "enable_track": False},
-        smoothquant_path=args.smoothquant_scale_path,
-        smoothquant_strict=not args.smoothquant_allow_missing,
+        backend=args.backend,
+        quant_config={
+            "smoothquant_path": args.smoothquant_scale_path,
+            "smoothquant_strict": not args.smoothquant_allow_missing,
+        },
     )
 
     all_scene_results: dict[str, dict] = {}

--- a/evaluation/test_dtu.py
+++ b/evaluation/test_dtu.py
@@ -430,8 +430,11 @@ def run_worker(
         model = load_model(
             args.model_path,
             model_args={"enable_point": False, "enable_track": False},
-            smoothquant_path=args.smoothquant_scale_path,
-            smoothquant_strict=not args.smoothquant_allow_missing,
+            backend=args.backend,
+            quant_config={
+                "smoothquant_path": args.smoothquant_scale_path,
+                "smoothquant_strict": not args.smoothquant_allow_missing,
+            },
         )
 
     try:
@@ -482,6 +485,13 @@ if __name__ == "__main__":
                         help="Path to SmoothQuant calibration artifact (.pt) for W8A16 attention inference.")
     parser.add_argument('--smoothquant_allow_missing', action='store_true',
                         help="Allow missing SmoothQuant scales for some attention layers.")
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="pseudo",
+        choices=["pseudo", "torchao", "bitsandbytes", "trt_int8"],
+        help="Quantization backend to use.",
+    )
     parser.add_argument('--dist_thresh', type=float, default=1.0,
                         help="Distance threshold for point cloud fusion consistency check.")
     parser.add_argument('--num_consist', type=int, default=4,
@@ -527,3 +537,4 @@ if __name__ == "__main__":
         else:
             logger.info("Running single-worker evaluation on CPU")
         run_worker(args, scene_names, worker_idx=0, gpu_id=selected_gpu)
+

--- a/evaluation/test_eth3d.py
+++ b/evaluation/test_eth3d.py
@@ -85,6 +85,13 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Allow missing SmoothQuant scales for some attention layers.",
     )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="pseudo",
+        choices=["pseudo", "torchao", "bitsandbytes", "trt_int8"],
+        help="Quantization backend to use.",
+    )
     return parser.parse_args()
 
 
@@ -795,8 +802,11 @@ def main() -> None:
             "enable_depth": False,
             "enable_track": False,
         },
-        smoothquant_path=args.smoothquant_scale_path,
-        smoothquant_strict=not args.smoothquant_allow_missing,
+        backend=args.backend,
+        quant_config={
+            "smoothquant_path": args.smoothquant_scale_path,
+            "smoothquant_strict": not args.smoothquant_allow_missing,
+        },
     )
 
     summary = []

--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -13,7 +13,7 @@ from urllib.request import urlretrieve
 import os
 import logging
 
-from vggt.quantization.smoothquant import apply_smoothquant_w8a16, load_smoothquant_artifact
+from vggt.quantization.backends import create_quant_backend
 
 HF_ENDPOINT = os.getenv("HF_ENDPOINT", "https://huggingface.co")
 MODEL_URL = f"{HF_ENDPOINT}/facebook/VGGT-1B/resolve/main/model.pt"
@@ -48,8 +48,8 @@ def _get_xy1_grid(height: int, width: int, device: torch.device) -> torch.Tensor
 def load_model(
     model_path: Path,
     model_args: Optional[dict] = None,
-    smoothquant_path: Optional[Path] = None,
-    smoothquant_strict: bool = True,
+    backend: str = "pseudo",
+    quant_config: Optional[dict] = None,
 ) -> VGGT:
     if not model_path.exists():
         logger.info(f"Model doesn't exists. Downloading from {MODEL_URL}...")
@@ -84,15 +84,9 @@ def load_model(
     if missing:
         logger.info(f"Missing keys when loading model: {missing}")
 
-    if smoothquant_path is not None:
-        artifact = load_smoothquant_artifact(smoothquant_path)
-        quant_info = apply_smoothquant_w8a16(model, artifact, strict=smoothquant_strict)
-        logger.info(
-            "Applied SmoothQuant W8A16 to %d attention linear layers (missing=%d, unused=%d)",
-            quant_info["replaced"],
-            len(quant_info["missing"]),
-            len(quant_info["unused"]),
-        )
+    quant_backend = create_quant_backend(backend)
+    model = quant_backend.prepare(model, quant_config=quant_config)
+    model = quant_backend.convert(model)
 
     model.eval()
     model = model.to(device)

--- a/vggt/quantization/backends/__init__.py
+++ b/vggt/quantization/backends/__init__.py
@@ -1,0 +1,5 @@
+from vggt.quantization.backends.base import QuantBackend
+from vggt.quantization.backends.factory import create_quant_backend
+from vggt.quantization.backends.pseudo import PseudoQuantBackend
+
+__all__ = ["QuantBackend", "PseudoQuantBackend", "create_quant_backend"]

--- a/vggt/quantization/backends/base.py
+++ b/vggt/quantization/backends/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping
+
+
+class QuantBackend(ABC):
+    """Unified quantization backend interface."""
+
+    @abstractmethod
+    def prepare(self, model: Any, quant_config: Mapping[str, Any] | None = None) -> Any:
+        """Prepare model/graph for quantization workflow."""
+
+    @abstractmethod
+    def convert(self, model_or_graph: Any) -> Any:
+        """Convert prepared model/graph into deployable quantized representation."""
+
+    @abstractmethod
+    def run(self, inputs: Any) -> Any:
+        """Execute inference with the converted backend artifact."""
+
+    @abstractmethod
+    def capabilities(self) -> Mapping[str, Any]:
+        """Return backend capabilities: bit-widths, operators, and devices."""

--- a/vggt/quantization/backends/factory.py
+++ b/vggt/quantization/backends/factory.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from vggt.quantization.backends.base import QuantBackend
+from vggt.quantization.backends.pseudo import PseudoQuantBackend
+
+
+def create_quant_backend(name: str) -> QuantBackend:
+    backend = name.lower()
+    if backend == "pseudo":
+        return PseudoQuantBackend()
+
+    if backend in {"torchao", "bitsandbytes", "trt_int8"}:
+        raise NotImplementedError(f"Quant backend '{backend}' is not implemented yet.")
+
+    raise ValueError(f"Unknown quant backend: {name}")

--- a/vggt/quantization/backends/pseudo.py
+++ b/vggt/quantization/backends/pseudo.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from vggt.quantization.backends.base import QuantBackend
+from vggt.quantization.smoothquant import apply_smoothquant_w8a16, load_smoothquant_artifact
+
+
+class PseudoQuantBackend(QuantBackend):
+    """Pseudo quant backend based on existing SmoothQuant W8A16 replacement."""
+
+    def __init__(self) -> None:
+        self._model = None
+
+    def prepare(self, model: Any, quant_config: Mapping[str, Any] | None = None) -> Any:
+        quant_config = quant_config or {}
+        smoothquant_path = quant_config.get("smoothquant_path")
+        strict = bool(quant_config.get("smoothquant_strict", True))
+
+        if smoothquant_path is not None:
+            artifact = load_smoothquant_artifact(Path(smoothquant_path))
+            apply_smoothquant_w8a16(model, artifact, strict=strict)
+
+        return model
+
+    def convert(self, model_or_graph: Any) -> Any:
+        self._model = model_or_graph
+        return self._model
+
+    def run(self, inputs: Any) -> Any:
+        if self._model is None:
+            raise RuntimeError("PseudoQuantBackend is not converted. Call convert() first.")
+        return self._model(inputs)
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": "pseudo",
+            "bit_widths": ["w8a16"],
+            "operators": ["linear(qkv,proj)"],
+            "devices": ["cpu", "cuda"],
+        }


### PR DESCRIPTION
### Motivation
- Decouple existing SmoothQuant-based pseudo-quantization from model loading so inference code depends on an abstract backend interface rather than concrete SmoothQuant calls.
- Provide a small, extensible backend API so multiple quant backends (`pseudo`, `torchao`, `bitsandbytes`, `trt_int8`) can be selected by configuration without branching in business logic.
- Encapsulate prepare/convert/run/capabilities lifecycle for backends to simplify future integration of real quant backends.

### Description
- Add an abstract backend interface `QuantBackend` with `prepare`, `convert`, `run`, and `capabilities` in `vggt/quantization/backends/base.py`.
- Implement `PseudoQuantBackend` in `vggt/quantization/backends/pseudo.py` that applies the existing SmoothQuant W8A16 replacement during `prepare` and exposes a no-op `convert`/`run` flow.
- Add a simple factory `create_quant_backend(name)` in `vggt/quantization/backends/factory.py` and public exports in `vggt/quantization/backends/__init__.py`; the factory currently returns `PseudoQuantBackend` or raises `NotImplementedError` for stubbed backends.
- Refactor `load_model` in `evaluation/utils.py` to accept `backend: str` and `quant_config: Optional[dict]` and to call `create_quant_backend(...).prepare(...)/convert(...)` instead of directly calling SmoothQuant helpers.
- Add `--backend` CLI flag to evaluation entrypoints and route SmoothQuant-related CLI args into `quant_config` passed to `load_model` in `evaluation/test_dtu.py`, `evaluation/test_7scenes.py`, and `evaluation/test_eth3d.py`.

### Testing
- Ran `python -m py_compile` over the modified and new modules (`evaluation/utils.py`, `evaluation/test_dtu.py`, `evaluation/test_7scenes.py`, `evaluation/test_eth3d.py`, and files under `vggt/quantization/backends`) and the compilation check succeeded.
- Attempted a `uv run python -m py_compile ...` environment run which failed to fetch external wheel dependencies due to network/mirror issues, but that failure was unrelated to the code changes and did not affect the local syntax checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f706eae574832c96b4ddf6f2b7a9a1)