### PR TITLE
Add RealQuantBackend MVP and unify quant inference stages

### DIFF
--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -29,6 +29,13 @@ else:
 logger = logging.getLogger(__name__)
 
 
+def run_quant_inference(model: VGGT, inputs: torch.Tensor):
+    backend = getattr(model, "_quant_backend", None)
+    if backend is None:
+        return model(inputs)
+    return backend.run(inputs)
+
+
 def _get_xy1_grid(height: int, width: int, device: torch.device) -> torch.Tensor:
     key = (str(device), height, width)
     cached = _XY1_CACHE.get(key)
@@ -87,6 +94,7 @@ def load_model(
     quant_backend = create_quant_backend(backend)
     model = quant_backend.prepare(model, quant_config=quant_config)
     model = quant_backend.convert(model)
+    setattr(model, "_quant_backend", quant_backend)
 
     model.eval()
     model = model.to(device)
@@ -114,7 +122,7 @@ def predict(images_path: List[Path], model: VGGT):
             profiler.record_snapshot("before_model_forward")
             with torch.amp.autocast('cuda', dtype=dtype): # pyright: ignore[reportPrivateImportUsage]
                 # Predict attributes including cameras, depth maps, and point maps
-                predictions = model(images)
+                predictions = run_quant_inference(model, images)
             profiler.record_snapshot("after_model_forward")
     except Exception as exc:
         profiler.record_error(exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "einops",
     "safetensors",
     "opencv-python",
+    "bitsandbytes",
 ]
 name = "vggt"
 requires-python = ">= 3.10"

--- a/vggt/quantization/backends/__init__.py
+++ b/vggt/quantization/backends/__init__.py
@@ -1,6 +1,6 @@
 from vggt.quantization.backends.base import QuantBackend
 from vggt.quantization.backends.factory import create_quant_backend
 from vggt.quantization.backends.pseudo import PseudoQuantBackend
-from vggt.quantization.backends.real import RealQuantBackend
+from vggt.quantization.backends.bitsandbytes import BitsandbytesQuantBackend
 
-__all__ = ["QuantBackend", "PseudoQuantBackend", "RealQuantBackend", "create_quant_backend"]
+__all__ = ["QuantBackend", "PseudoQuantBackend", "BitsandbytesQuantBackend", "create_quant_backend"]

--- a/vggt/quantization/backends/__init__.py
+++ b/vggt/quantization/backends/__init__.py
@@ -1,5 +1,6 @@
 from vggt.quantization.backends.base import QuantBackend
 from vggt.quantization.backends.factory import create_quant_backend
 from vggt.quantization.backends.pseudo import PseudoQuantBackend
+from vggt.quantization.backends.real import RealQuantBackend
 
-__all__ = ["QuantBackend", "PseudoQuantBackend", "create_quant_backend"]
+__all__ = ["QuantBackend", "PseudoQuantBackend", "RealQuantBackend", "create_quant_backend"]

--- a/vggt/quantization/backends/bitsandbytes.py
+++ b/vggt/quantization/backends/bitsandbytes.py
@@ -11,8 +11,8 @@ from vggt.quantization.backends.base import QuantBackend
 logger = logging.getLogger(__name__)
 
 
-class RealQuantBackend(QuantBackend):
-    """Real quant backend MVP using bitsandbytes linear replacement when available."""
+class BitsandbytesQuantBackend(QuantBackend):
+    """Bitsandbytes quant backend MVP using Linear8bitLt replacement."""
 
     def __init__(self) -> None:
         self._model: nn.Module | None = None
@@ -25,7 +25,7 @@ class RealQuantBackend(QuantBackend):
         keywords = quant_config.get("target_linear_keywords")
         if keywords:
             self._target_keywords = tuple(str(k) for k in keywords)
-        logger.info("[RealQuantBackend] prepare done. target keywords=%s", self._target_keywords)
+        logger.info("[BitsandbytesQuantBackend] prepare done. target keywords=%s", self._target_keywords)
         return model
 
     def convert(self, model_or_graph: Any) -> Any:
@@ -35,7 +35,7 @@ class RealQuantBackend(QuantBackend):
             import bitsandbytes as bnb  # type: ignore
         except ImportError:
             logger.warning(
-                "[RealQuantBackend] bitsandbytes is not installed; fallback to FP16/FP32 for all layers."
+                "[BitsandbytesQuantBackend] bitsandbytes is not installed; fallback to FP16/FP32 for all layers."
             )
             self._model = model
             self._converted = True
@@ -47,7 +47,7 @@ class RealQuantBackend(QuantBackend):
                 continue
             if not any(token in name.lower() for token in self._target_keywords):
                 fallback += 1
-                logger.info("[RealQuantBackend] fallback layer=%s (not in target keywords)", name)
+                logger.info("[BitsandbytesQuantBackend] fallback layer=%s (not in target keywords)", name)
                 continue
 
             parent_name, child_name = name.rsplit(".", 1) if "." in name else ("", name)
@@ -67,7 +67,7 @@ class RealQuantBackend(QuantBackend):
             replaced += 1
 
         logger.info(
-            "[RealQuantBackend] convert done. replaced=%d, fallback_fp=%d",
+            "[BitsandbytesQuantBackend] convert done. replaced=%d, fallback_fp=%d",
             replaced,
             fallback,
         )
@@ -78,12 +78,12 @@ class RealQuantBackend(QuantBackend):
 
     def run(self, inputs: Any) -> Any:
         if self._model is None or not self._converted:
-            raise RuntimeError("RealQuantBackend is not converted. Call convert() first.")
+            raise RuntimeError("BitsandbytesQuantBackend is not converted. Call convert() first.")
         return self._model(inputs)
 
     def capabilities(self) -> Mapping[str, Any]:
         return {
-            "name": "real",
+            "name": "bitsandbytes",
             "bit_widths": ["int8"],
             "operators": ["linear(qkv,proj,fc,mlp)"],
             "devices": ["cuda"],

--- a/vggt/quantization/backends/factory.py
+++ b/vggt/quantization/backends/factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from vggt.quantization.backends.base import QuantBackend
 from vggt.quantization.backends.pseudo import PseudoQuantBackend
+from vggt.quantization.backends.real import RealQuantBackend
 
 
 def create_quant_backend(name: str) -> QuantBackend:
@@ -9,7 +10,10 @@ def create_quant_backend(name: str) -> QuantBackend:
     if backend == "pseudo":
         return PseudoQuantBackend()
 
-    if backend in {"torchao", "bitsandbytes", "trt_int8"}:
+    if backend in {"real", "bitsandbytes"}:
+        return RealQuantBackend()
+
+    if backend in {"torchao", "trt_int8"}:
         raise NotImplementedError(f"Quant backend '{backend}' is not implemented yet.")
 
     raise ValueError(f"Unknown quant backend: {name}")

--- a/vggt/quantization/backends/factory.py
+++ b/vggt/quantization/backends/factory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from vggt.quantization.backends.base import QuantBackend
 from vggt.quantization.backends.pseudo import PseudoQuantBackend
-from vggt.quantization.backends.real import RealQuantBackend
+from vggt.quantization.backends.bitsandbytes import BitsandbytesQuantBackend
 
 
 def create_quant_backend(name: str) -> QuantBackend:
@@ -10,8 +10,8 @@ def create_quant_backend(name: str) -> QuantBackend:
     if backend == "pseudo":
         return PseudoQuantBackend()
 
-    if backend in {"real", "bitsandbytes"}:
-        return RealQuantBackend()
+    if backend == "bitsandbytes":
+        return BitsandbytesQuantBackend()
 
     if backend in {"torchao", "trt_int8"}:
         raise NotImplementedError(f"Quant backend '{backend}' is not implemented yet.")

--- a/vggt/quantization/backends/real.py
+++ b/vggt/quantization/backends/real.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+import torch
+import torch.nn as nn
+
+from vggt.quantization.backends.base import QuantBackend
+
+logger = logging.getLogger(__name__)
+
+
+class RealQuantBackend(QuantBackend):
+    """Real quant backend MVP using bitsandbytes linear replacement when available."""
+
+    def __init__(self) -> None:
+        self._model: nn.Module | None = None
+        self._converted = False
+        self._target_keywords = ("qkv", "proj", "fc", "mlp")
+
+    def prepare(self, model: Any, quant_config: Mapping[str, Any] | None = None) -> Any:
+        self._model = model
+        quant_config = quant_config or {}
+        keywords = quant_config.get("target_linear_keywords")
+        if keywords:
+            self._target_keywords = tuple(str(k) for k in keywords)
+        logger.info("[RealQuantBackend] prepare done. target keywords=%s", self._target_keywords)
+        return model
+
+    def convert(self, model_or_graph: Any) -> Any:
+        model = model_or_graph
+
+        try:
+            import bitsandbytes as bnb  # type: ignore
+        except ImportError:
+            logger.warning(
+                "[RealQuantBackend] bitsandbytes is not installed; fallback to FP16/FP32 for all layers."
+            )
+            self._model = model
+            self._converted = True
+            return model
+
+        replaced, fallback = 0, 0
+        for name, module in list(model.named_modules()):
+            if not isinstance(module, nn.Linear):
+                continue
+            if not any(token in name.lower() for token in self._target_keywords):
+                fallback += 1
+                logger.info("[RealQuantBackend] fallback layer=%s (not in target keywords)", name)
+                continue
+
+            parent_name, child_name = name.rsplit(".", 1) if "." in name else ("", name)
+            parent = model.get_submodule(parent_name) if parent_name else model
+
+            qlinear = bnb.nn.Linear8bitLt(
+                module.in_features,
+                module.out_features,
+                bias=module.bias is not None,
+                has_fp16_weights=True,
+            )
+            qlinear.weight.data.copy_(module.weight.data)
+            if module.bias is not None and qlinear.bias is not None:
+                qlinear.bias.data.copy_(module.bias.data)
+
+            setattr(parent, child_name, qlinear)
+            replaced += 1
+
+        logger.info(
+            "[RealQuantBackend] convert done. replaced=%d, fallback_fp=%d",
+            replaced,
+            fallback,
+        )
+
+        self._model = model
+        self._converted = True
+        return model
+
+    def run(self, inputs: Any) -> Any:
+        if self._model is None or not self._converted:
+            raise RuntimeError("RealQuantBackend is not converted. Call convert() first.")
+        return self._model(inputs)
+
+    def capabilities(self) -> Mapping[str, Any]:
+        return {
+            "name": "real",
+            "bit_widths": ["int8"],
+            "operators": ["linear(qkv,proj,fc,mlp)"],
+            "devices": ["cuda"],
+            "fallback": "unsupported layers remain FP16/FP32 with logging",
+        }


### PR DESCRIPTION
### Motivation
- Provide a real quantization backend option that performs weight quantization for inference using an existing library backend.
- Ensure the quantization workflow follows a shared `prepare -> convert -> run` call chain so pseudo and real backends are comparable.
- Fail gracefully for unsupported layers or missing dependencies while keeping pre/post-processing and the existing model I/O unchanged.

### Description
- Add `RealQuantBackend` at `vggt/quantization/backends/real.py` implementing `prepare`, `convert`, `run`, and `capabilities` and targeting linear layers by configurable keywords (default: `qkv`, `proj`, `fc`, `mlp`).
- In `convert`, attempt to replace selected `nn.Linear` modules with `bitsandbytes.nn.Linear8bitLt`, copy weights/biases, and log per-layer replacements and fallbacks.
- If `bitsandbytes` is not installed, emit a warning and fall back to leaving modules as FP16/FP32.
- Update backend wiring by exporting `RealQuantBackend` and extending `create_quant_backend` to return it for backend names `real` and `bitsandbytes`.
- Modify `evaluation/utils.py` to run `prepare` and `convert` during `load_model`, attach the backend on the model via `model._quant_backend`, and introduce `run_quant_inference()` so `predict()` calls backend `run()` when present, keeping the input preprocessing/postprocessing unchanged.

### Testing
- Compiled modified modules with `python -m compileall vggt/quantization/backends evaluation/utils.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f717d4a15c832c8590edeea034c532)